### PR TITLE
Add descriptive error message for failing to use together with HtmlWebpackPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@ class InterpolateHtmlPlugin {
 
   apply(compiler) {
     compiler.hooks.compilation.tap('InterpolateHtmlPlugin', compilation => {
+      if (!compilation.hooks.htmlWebpackPluginBeforeHtmlProcessing) {
+        throw new Error('Could not find the required plugin hook. Please verify ' +
+          'that InterpolateHtmlPlugin appears after HtmlWebpackPlugin in your webpack config.')
+      }
       compilation.hooks.htmlWebpackPluginBeforeHtmlProcessing.tap(
         'InterpolateHtmlPlugin',
         data => {


### PR DESCRIPTION
Currently, it throws `Cannot read property 'tap' of undefined ` during build, if attempting to use InterpolateHtmlPlugin before (or without) HtmlWebpackPlugin.

This is a suggestion for adding a more descriptive error message, since a number of people (including me) seems to have run into this issue when upgrading webpack, using build configs set up by create-react-app.